### PR TITLE
[Refactor/#22] spring security 응답 포맷 통일

### DIFF
--- a/src/main/java/com/example/ssccwebbe/domain/preuser/code/PreUserErrorCode.java
+++ b/src/main/java/com/example/ssccwebbe/domain/preuser/code/PreUserErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.ssccwebbe.domain.preuser.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.ssccwebbe.global.apipayload.code.error.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PreUserErrorCode implements ErrorCode {
+
+    // PreUser 관련 404 NOT_FOUND 에러
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PREUSER4041", "해당 유저를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/ssccwebbe/domain/preuser/service/PreUserServiceImpl.java
+++ b/src/main/java/com/example/ssccwebbe/domain/preuser/service/PreUserServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,7 +65,8 @@ public class PreUserServiceImpl extends DefaultOAuth2UserService implements PreU
 
             // 구글이 아닌 경우
         } else {
-            throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다.");
+            OAuth2Error error = new OAuth2Error("unsupported_provider", "지원하지 않는 소셜 로그인입니다.", null);
+            throw new OAuth2AuthenticationException(error);
         }
 
         // 데이터베이스 조회 -> 존재하면 업데이트, 없으면 신규 가입

--- a/src/main/java/com/example/ssccwebbe/domain/preuser/service/PreUserServiceImpl.java
+++ b/src/main/java/com/example/ssccwebbe/domain/preuser/service/PreUserServiceImpl.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -16,12 +15,14 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.ssccwebbe.domain.preuser.code.PreUserErrorCode;
 import com.example.ssccwebbe.domain.preuser.dto.CustomOAuth2PreUser;
 import com.example.ssccwebbe.domain.preuser.dto.PreUserRequestDto;
 import com.example.ssccwebbe.domain.preuser.dto.PreUserResponseDto;
 import com.example.ssccwebbe.domain.preuser.entity.PreUserEntity;
 import com.example.ssccwebbe.domain.preuser.entity.SocialProviderType;
 import com.example.ssccwebbe.domain.preuser.repository.PreUserRepository;
+import com.example.ssccwebbe.global.apipayload.exception.GeneralException;
 import com.example.ssccwebbe.global.security.UserRoleType;
 
 import lombok.RequiredArgsConstructor;
@@ -121,10 +122,7 @@ public class PreUserServiceImpl extends DefaultOAuth2UserService implements PreU
         PreUserEntity entity =
                 preUserRepository
                         .findByUsernameAndIsLock(username, false)
-                        .orElseThrow(
-                                () ->
-                                        new UsernameNotFoundException(
-                                                "해당 유저를 찾을 수 없습니다: " + username));
+                        .orElseThrow(() -> new GeneralException(PreUserErrorCode.USER_NOT_FOUND));
 
         return new PreUserResponseDto(
                 username, entity.getIsSocial(), entity.getNickname(), entity.getEmail());

--- a/src/main/java/com/example/ssccwebbe/global/apipayload/code/error/CommonErrorCode.java
+++ b/src/main/java/com/example/ssccwebbe/global/apipayload/code/error/CommonErrorCode.java
@@ -13,6 +13,7 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON400", "파라미터가 올바르지 않습니다."),
     INVALID_BODY(HttpStatus.BAD_REQUEST, "COMMON400", "요청 본문이 올바르지 않습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "찾을 수 없는 리소스입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "허용되지 않는 HTTP Method입니다."),

--- a/src/main/java/com/example/ssccwebbe/global/security/code/OAuth2ErrorCode.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/code/OAuth2ErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.ssccwebbe.global.security.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.ssccwebbe.global.apipayload.code.error.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OAuth2ErrorCode implements ErrorCode {
+
+    // OAuth2 관련 401 UNAUTHORIZED 에러
+    UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "OAUTH4001", "지원하지 않는 소셜 로그인입니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "OAUTH4002", "소셜 로그인에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/ssccwebbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -32,6 +33,7 @@ import com.example.ssccwebbe.global.security.jwt.service.JwtService;
 public class SecurityConfig {
 
     private final AuthenticationSuccessHandler socialSuccessHandler;
+    private final AuthenticationFailureHandler socialFailureHandler;
     private final JwtService jwtService;
 
     @Value("${frontend.url}")
@@ -40,8 +42,10 @@ public class SecurityConfig {
     //  LoginSuccessHandler 빈을 명확히 주입 받기 위해 Qualifier 설정 도입
     public SecurityConfig(
             @Qualifier("SocialSuccessHandler") AuthenticationSuccessHandler socialSuccessHandler,
+            @Qualifier("SocialFailureHandler") AuthenticationFailureHandler socialFailureHandler,
             JwtService jwtService) {
         this.socialSuccessHandler = socialSuccessHandler;
+        this.socialFailureHandler = socialFailureHandler;
         this.jwtService = jwtService;
     }
 
@@ -92,7 +96,10 @@ public class SecurityConfig {
         http.httpBasic(AbstractHttpConfigurer::disable);
 
         // OAuth2 인증용
-        http.oauth2Login(oauth2 -> oauth2.successHandler(socialSuccessHandler));
+        http.oauth2Login(
+                oauth2 ->
+                        oauth2.successHandler(socialSuccessHandler)
+                                .failureHandler(socialFailureHandler));
 
         // 인가
         http.authorizeHttpRequests(

--- a/src/main/java/com/example/ssccwebbe/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/config/SecurityConfig.java
@@ -2,8 +2,6 @@ package com.example.ssccwebbe.global.security.config;
 
 import java.util.List;
 
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,7 +13,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
@@ -34,6 +34,8 @@ public class SecurityConfig {
 
     private final AuthenticationSuccessHandler socialSuccessHandler;
     private final AuthenticationFailureHandler socialFailureHandler;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final AccessDeniedHandler accessDeniedHandler;
     private final JwtService jwtService;
 
     @Value("${frontend.url}")
@@ -43,9 +45,13 @@ public class SecurityConfig {
     public SecurityConfig(
             @Qualifier("SocialSuccessHandler") AuthenticationSuccessHandler socialSuccessHandler,
             @Qualifier("SocialFailureHandler") AuthenticationFailureHandler socialFailureHandler,
+            AuthenticationEntryPoint authenticationEntryPoint,
+            AccessDeniedHandler accessDeniedHandler,
             JwtService jwtService) {
         this.socialSuccessHandler = socialSuccessHandler;
         this.socialFailureHandler = socialFailureHandler;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
         this.jwtService = jwtService;
     }
 
@@ -123,21 +129,8 @@ public class SecurityConfig {
         // 예외 처리
         http.exceptionHandling(
                 e ->
-                        e.authenticationEntryPoint(
-                                        (request, response, authException) -> {
-                                            response.sendError(
-                                                    HttpServletResponse
-                                                            .SC_UNAUTHORIZED); // 401 응답, 로그인이 필요한
-                                            // 경로이나, 로그인을 하지 않은
-                                            // 경우
-                                        })
-                                .accessDeniedHandler(
-                                        (request, response, authException) -> {
-                                            response.sendError(
-                                                    HttpServletResponse
-                                                            .SC_FORBIDDEN); // 403 응답, 로그인을 하였으나 권한이
-                                            // 없는 경우
-                                        }));
+                        e.authenticationEntryPoint(authenticationEntryPoint)
+                                .accessDeniedHandler(accessDeniedHandler));
 
         // 커스텀 필터 추가 (로그아웃 필터 앞에 넣음)
         http.addFilterBefore(new JwtFilter(), LogoutFilter.class);

--- a/src/main/java/com/example/ssccwebbe/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,41 @@
+package com.example.ssccwebbe.global.security.handler;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.example.ssccwebbe.global.apipayload.ApiResponse;
+import com.example.ssccwebbe.global.apipayload.code.error.CommonErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException {
+
+        log.warn("Access denied: {}", accessDeniedException.getMessage());
+
+        // ApiResponse 형식으로 응답 작성
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<?> errorResponse =
+                ApiResponse.fail(
+                        CommonErrorCode.FORBIDDEN, "접근 권한이 없습니다."); // 403 응답, 로그인을 하였으나 권한이 없는 경우
+        ObjectMapper mapper = new ObjectMapper();
+        response.getWriter().write(mapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/example/ssccwebbe/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/handler/CustomAccessDeniedHandler.java
@@ -29,7 +29,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         log.warn("Access denied: {}", accessDeniedException.getMessage());
 
         // ApiResponse 형식으로 응답 작성
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setStatus(CommonErrorCode.FORBIDDEN.getHttpStatus().value());
         response.setContentType("application/json;charset=UTF-8");
 
         ApiResponse<?> errorResponse =

--- a/src/main/java/com/example/ssccwebbe/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -29,12 +29,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         log.warn("Authentication failed: {}", authException.getMessage());
 
         // ApiResponse 형식으로 응답 작성
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(CommonErrorCode.UNAUTHORIZED.getHttpStatus().value());
         response.setContentType("application/json;charset=UTF-8");
 
         ApiResponse<?> errorResponse =
                 ApiResponse.fail(
-                        CommonErrorCode.BAD_REQUEST,
+                        CommonErrorCode.UNAUTHORIZED,
                         "인증이 필요합니다. 로그인 후 다시 시도해주세요."); // 401 응답, 로그인이 필요한 경로이나 로그인을 하지 않은 경우
         ObjectMapper mapper = new ObjectMapper();
         response.getWriter().write(mapper.writeValueAsString(errorResponse));

--- a/src/main/java/com/example/ssccwebbe/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.example.ssccwebbe.global.security.handler;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.example.ssccwebbe.global.apipayload.ApiResponse;
+import com.example.ssccwebbe.global.apipayload.code.error.CommonErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException {
+
+        log.warn("Authentication failed: {}", authException.getMessage());
+
+        // ApiResponse 형식으로 응답 작성
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<?> errorResponse =
+                ApiResponse.fail(
+                        CommonErrorCode.BAD_REQUEST,
+                        "인증이 필요합니다. 로그인 후 다시 시도해주세요."); // 401 응답, 로그인이 필요한 경로이나 로그인을 하지 않은 경우
+        ObjectMapper mapper = new ObjectMapper();
+        response.getWriter().write(mapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/example/ssccwebbe/global/security/handler/RefreshTokenLogoutHandler.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/handler/RefreshTokenLogoutHandler.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.util.StringUtils;
 
+import com.example.ssccwebbe.global.apipayload.exception.GeneralException;
+import com.example.ssccwebbe.global.security.jwt.code.JwtErrorCode;
 import com.example.ssccwebbe.global.security.jwt.service.JwtService;
 import com.example.ssccwebbe.global.security.jwt.util.JwtUtil;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -57,7 +59,7 @@ public class RefreshTokenLogoutHandler implements LogoutHandler {
             jwtService.removeRefresh(refreshToken);
 
         } catch (IOException e) {
-            throw new RuntimeException("Failed to read refresh token", e);
+            throw new GeneralException(JwtErrorCode.REFRESH_TOKEN_READ_FAILED);
         }
     }
 }

--- a/src/main/java/com/example/ssccwebbe/global/security/handler/RefreshTokenLogoutHandler.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/handler/RefreshTokenLogoutHandler.java
@@ -11,13 +11,14 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.util.StringUtils;
 
-import com.example.ssccwebbe.global.apipayload.exception.GeneralException;
-import com.example.ssccwebbe.global.security.jwt.code.JwtErrorCode;
 import com.example.ssccwebbe.global.security.jwt.service.JwtService;
 import com.example.ssccwebbe.global.security.jwt.util.JwtUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class RefreshTokenLogoutHandler implements LogoutHandler {
 
     private final JwtService jwtService;
@@ -59,7 +60,8 @@ public class RefreshTokenLogoutHandler implements LogoutHandler {
             jwtService.removeRefresh(refreshToken);
 
         } catch (IOException e) {
-            throw new GeneralException(JwtErrorCode.REFRESH_TOKEN_READ_FAILED);
+            // 조용히 실패 - logout 자체는 계속 진행
+            log.warn("Failed to read refresh token during logout", e);
         }
     }
 }

--- a/src/main/java/com/example/ssccwebbe/global/security/handler/SocialFailureHandler.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/handler/SocialFailureHandler.java
@@ -1,0 +1,54 @@
+package com.example.ssccwebbe.global.security.handler;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import com.example.ssccwebbe.global.apipayload.ApiResponse;
+import com.example.ssccwebbe.global.apipayload.code.error.ErrorCode;
+import com.example.ssccwebbe.global.security.code.OAuth2ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component("SocialFailureHandler")
+public class SocialFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception)
+            throws IOException {
+
+        log.warn("OAuth2 authentication failed: {}", exception.getMessage());
+
+        // OAuth2AuthenticationException인 경우 에러 코드에 따라 적절한 에러 코드 선택
+        ErrorCode errorCode;
+        if (exception instanceof OAuth2AuthenticationException oauth2Exception) {
+            String oauth2ErrorCode = oauth2Exception.getError().getErrorCode();
+            if ("unsupported_provider".equals(oauth2ErrorCode)) {
+                errorCode = OAuth2ErrorCode.UNSUPPORTED_PROVIDER;
+            } else {
+                errorCode = OAuth2ErrorCode.AUTHENTICATION_FAILED;
+            }
+        } else {
+            errorCode = OAuth2ErrorCode.AUTHENTICATION_FAILED;
+        }
+
+        // ApiResponse 형식으로 응답 작성
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<?> errorResponse = ApiResponse.fail(errorCode);
+        ObjectMapper mapper = new ObjectMapper();
+        response.getWriter().write(mapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/example/ssccwebbe/global/security/jwt/code/JwtErrorCode.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/jwt/code/JwtErrorCode.java
@@ -17,6 +17,7 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "JWT4003", "유효하지 않은 refreshToken입니다."),
     REFRESH_TOKEN_NOT_IN_WHITELIST(
             HttpStatus.UNAUTHORIZED, "JWT4004", "화이트리스트에 없는 refreshToken입니다."),
+    REFRESH_TOKEN_READ_FAILED(HttpStatus.BAD_REQUEST, "JWT4005", "Refresh 토큰을 읽을 수 없습니다."),
 
     // JWT 관련 403 FORBIDDEN 에러
     EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "JWT4031", "만료된 토큰입니다."),

--- a/src/main/java/com/example/ssccwebbe/global/security/jwt/code/JwtErrorCode.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/jwt/code/JwtErrorCode.java
@@ -11,6 +11,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum JwtErrorCode implements ErrorCode {
 
+    // JWT 관련 400 BAD_REQUEST 에러
+    INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "JWT4000", "Bearer 토큰 형식이 아닙니다."),
+
     // JWT 관련 401 UNAUTHORIZED 에러
     COOKIE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT4001", "쿠키가 존재하지 않습니다."),
     REFRESH_TOKEN_COOKIE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT4002", "refreshToken 쿠키가 없습니다."),

--- a/src/main/java/com/example/ssccwebbe/global/security/jwt/code/JwtErrorCode.java
+++ b/src/main/java/com/example/ssccwebbe/global/security/jwt/code/JwtErrorCode.java
@@ -17,7 +17,6 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "JWT4003", "유효하지 않은 refreshToken입니다."),
     REFRESH_TOKEN_NOT_IN_WHITELIST(
             HttpStatus.UNAUTHORIZED, "JWT4004", "화이트리스트에 없는 refreshToken입니다."),
-    REFRESH_TOKEN_READ_FAILED(HttpStatus.BAD_REQUEST, "JWT4005", "Refresh 토큰을 읽을 수 없습니다."),
 
     // JWT 관련 403 FORBIDDEN 에러
     EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "JWT4031", "만료된 토큰입니다."),

--- a/src/test/java/com/example/ssccwebbe/domain/preuser/service/PreUserServiceImplTest.java
+++ b/src/test/java/com/example/ssccwebbe/domain/preuser/service/PreUserServiceImplTest.java
@@ -16,12 +16,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
+import com.example.ssccwebbe.domain.preuser.code.PreUserErrorCode;
 import com.example.ssccwebbe.domain.preuser.dto.PreUserResponseDto;
 import com.example.ssccwebbe.domain.preuser.entity.PreUserEntity;
 import com.example.ssccwebbe.domain.preuser.entity.SocialProviderType;
 import com.example.ssccwebbe.domain.preuser.repository.PreUserRepository;
+import com.example.ssccwebbe.global.apipayload.exception.GeneralException;
 import com.example.ssccwebbe.global.security.UserRoleType;
 
 @ExtendWith(MockitoExtension.class)
@@ -115,7 +116,7 @@ class PreUserServiceImplTest {
     }
 
     @Test
-    @DisplayName("readPreUser - 존재하지 않는 사용자 조회 시 UsernameNotFoundException 발생")
+    @DisplayName("readPreUser - 존재하지 않는 사용자 조회 시 GeneralException 발생")
     void readPreUser_UserNotFound_ThrowsException() {
         // given
         String username = "nonexistent@test.com";
@@ -129,11 +130,11 @@ class PreUserServiceImplTest {
                 .thenReturn(Optional.empty());
 
         // when & then
-        org.junit.jupiter.api.Assertions.assertThrows(
-                UsernameNotFoundException.class,
-                () -> preUserService.readPreUser(),
-                "해당 유저를 찾을 수 없습니다: " + username);
+        GeneralException exception =
+                org.junit.jupiter.api.Assertions.assertThrows(
+                        GeneralException.class, () -> preUserService.readPreUser());
 
+        assertThat(exception.getErrorCode()).isEqualTo(PreUserErrorCode.USER_NOT_FOUND);
         verify(preUserRepository, times(1)).findByUsernameAndIsLock(username, false);
     }
 
@@ -153,9 +154,11 @@ class PreUserServiceImplTest {
                 .thenReturn(Optional.empty());
 
         // when & then
-        org.junit.jupiter.api.Assertions.assertThrows(
-                UsernameNotFoundException.class, () -> preUserService.readPreUser());
+        GeneralException exception =
+                org.junit.jupiter.api.Assertions.assertThrows(
+                        GeneralException.class, () -> preUserService.readPreUser());
 
+        assertThat(exception.getErrorCode()).isEqualTo(PreUserErrorCode.USER_NOT_FOUND);
         verify(preUserRepository, times(1)).findByUsernameAndIsLock(username, false);
     }
 

--- a/src/test/java/com/example/ssccwebbe/global/security/handler/CustomAccessDeniedHandlerTest.java
+++ b/src/test/java/com/example/ssccwebbe/global/security/handler/CustomAccessDeniedHandlerTest.java
@@ -1,0 +1,97 @@
+package com.example.ssccwebbe.global.security.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.example.ssccwebbe.global.apipayload.code.error.CommonErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class CustomAccessDeniedHandlerTest {
+
+    private CustomAccessDeniedHandler accessDeniedHandler;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private StringWriter stringWriter;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        accessDeniedHandler = new CustomAccessDeniedHandler();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        stringWriter = new StringWriter();
+        objectMapper = new ObjectMapper();
+
+        when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+    }
+
+    @Test
+    @DisplayName("접근 거부 시 ApiResponse 형식으로 403 응답")
+    void testAccessDenied() throws IOException {
+        // given
+        AccessDeniedException exception = new AccessDeniedException("접근 거부");
+
+        // when
+        accessDeniedHandler.handle(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        assertThat(jsonNode.get("success").asBoolean()).isFalse();
+        assertThat(jsonNode.get("code").asText()).isEqualTo(CommonErrorCode.FORBIDDEN.getCode());
+        assertThat(jsonNode.get("message").asText()).isEqualTo("접근 권한이 없습니다.");
+        assertThat(jsonNode.get("data").isNull()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다양한 접근 거부 예외에 대해 동일한 응답 형식 반환")
+    void testVariousAccessDeniedExceptions() throws IOException {
+        // given
+        AccessDeniedException exception = new AccessDeniedException("권한 부족");
+
+        // when
+        accessDeniedHandler.handle(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        assertThat(jsonNode.get("success").asBoolean()).isFalse();
+        assertThat(jsonNode.get("code").asText()).isEqualTo(CommonErrorCode.FORBIDDEN.getCode());
+    }
+
+    @Test
+    @DisplayName("JSON 응답이 올바른 구조를 가지고 있음")
+    void testJsonStructure() throws IOException {
+        // given
+        AccessDeniedException exception = new AccessDeniedException("접근 거부");
+
+        // when
+        accessDeniedHandler.handle(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        // ApiResponse의 4가지 필드 검증
+        assertThat(jsonNode.has("success")).isTrue();
+        assertThat(jsonNode.has("code")).isTrue();
+        assertThat(jsonNode.has("message")).isTrue();
+        assertThat(jsonNode.has("data")).isTrue();
+    }
+}

--- a/src/test/java/com/example/ssccwebbe/global/security/handler/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/com/example/ssccwebbe/global/security/handler/CustomAuthenticationEntryPointTest.java
@@ -53,7 +53,7 @@ class CustomAuthenticationEntryPointTest {
         JsonNode jsonNode = objectMapper.readTree(responseBody);
 
         assertThat(jsonNode.get("success").asBoolean()).isFalse();
-        assertThat(jsonNode.get("code").asText()).isEqualTo(CommonErrorCode.BAD_REQUEST.getCode());
+        assertThat(jsonNode.get("code").asText()).isEqualTo(CommonErrorCode.UNAUTHORIZED.getCode());
         assertThat(jsonNode.get("message").asText()).isEqualTo("인증이 필요합니다. 로그인 후 다시 시도해주세요.");
         assertThat(jsonNode.get("data").isNull()).isTrue();
     }
@@ -72,7 +72,7 @@ class CustomAuthenticationEntryPointTest {
         JsonNode jsonNode = objectMapper.readTree(responseBody);
 
         assertThat(jsonNode.get("success").asBoolean()).isFalse();
-        assertThat(jsonNode.get("code").asText()).isEqualTo(CommonErrorCode.BAD_REQUEST.getCode());
+        assertThat(jsonNode.get("code").asText()).isEqualTo(CommonErrorCode.UNAUTHORIZED.getCode());
     }
 
     @Test

--- a/src/test/java/com/example/ssccwebbe/global/security/handler/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/com/example/ssccwebbe/global/security/handler/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,97 @@
+package com.example.ssccwebbe.global.security.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import com.example.ssccwebbe.global.apipayload.code.error.CommonErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class CustomAuthenticationEntryPointTest {
+
+    private CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private StringWriter stringWriter;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        authenticationEntryPoint = new CustomAuthenticationEntryPoint();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        stringWriter = new StringWriter();
+        objectMapper = new ObjectMapper();
+
+        when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+    }
+
+    @Test
+    @DisplayName("인증 실패 시 ApiResponse 형식으로 401 응답")
+    void testAuthenticationFailure() throws IOException {
+        // given
+        BadCredentialsException exception = new BadCredentialsException("자격 증명 실패");
+
+        // when
+        authenticationEntryPoint.commence(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        assertThat(jsonNode.get("success").asBoolean()).isFalse();
+        assertThat(jsonNode.get("code").asText()).isEqualTo(CommonErrorCode.BAD_REQUEST.getCode());
+        assertThat(jsonNode.get("message").asText()).isEqualTo("인증이 필요합니다. 로그인 후 다시 시도해주세요.");
+        assertThat(jsonNode.get("data").isNull()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다양한 인증 예외에 대해 동일한 응답 형식 반환")
+    void testVariousAuthenticationExceptions() throws IOException {
+        // given
+        BadCredentialsException exception = new BadCredentialsException("다른 인증 오류");
+
+        // when
+        authenticationEntryPoint.commence(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        assertThat(jsonNode.get("success").asBoolean()).isFalse();
+        assertThat(jsonNode.get("code").asText()).isEqualTo(CommonErrorCode.BAD_REQUEST.getCode());
+    }
+
+    @Test
+    @DisplayName("JSON 응답이 올바른 구조를 가지고 있음")
+    void testJsonStructure() throws IOException {
+        // given
+        BadCredentialsException exception = new BadCredentialsException("인증 실패");
+
+        // when
+        authenticationEntryPoint.commence(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        // ApiResponse의 4가지 필드 검증
+        assertThat(jsonNode.has("success")).isTrue();
+        assertThat(jsonNode.has("code")).isTrue();
+        assertThat(jsonNode.has("message")).isTrue();
+        assertThat(jsonNode.has("data")).isTrue();
+    }
+}

--- a/src/test/java/com/example/ssccwebbe/global/security/handler/SocialFailureHandlerTest.java
+++ b/src/test/java/com/example/ssccwebbe/global/security/handler/SocialFailureHandlerTest.java
@@ -1,0 +1,120 @@
+package com.example.ssccwebbe.global.security.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+import com.example.ssccwebbe.global.security.code.OAuth2ErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class SocialFailureHandlerTest {
+
+    private SocialFailureHandler socialFailureHandler;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private StringWriter stringWriter;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        socialFailureHandler = new SocialFailureHandler();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        stringWriter = new StringWriter();
+        objectMapper = new ObjectMapper();
+
+        when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 소셜 로그인 예외 발생 시 UNSUPPORTED_PROVIDER 에러 응답")
+    void testUnsupportedProvider() throws IOException {
+        // given
+        OAuth2Error error = new OAuth2Error("unsupported_provider", "지원하지 않는 소셜 로그인입니다.", null);
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(error);
+
+        // when
+        socialFailureHandler.onAuthenticationFailure(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        assertThat(jsonNode.get("success").asBoolean()).isFalse();
+        assertThat(jsonNode.get("code").asText())
+                .isEqualTo(OAuth2ErrorCode.UNSUPPORTED_PROVIDER.getCode());
+        assertThat(jsonNode.get("message").asText())
+                .isEqualTo(OAuth2ErrorCode.UNSUPPORTED_PROVIDER.getMessage());
+    }
+
+    @Test
+    @DisplayName("일반 OAuth2 인증 예외 발생 시 AUTHENTICATION_FAILED 에러 응답")
+    void testAuthenticationFailed() throws IOException {
+        // given
+        OAuth2Error error = new OAuth2Error("authentication_failed", "OAuth2 인증에 실패했습니다.", null);
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(error);
+
+        // when
+        socialFailureHandler.onAuthenticationFailure(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        assertThat(jsonNode.get("success").asBoolean()).isFalse();
+        assertThat(jsonNode.get("code").asText())
+                .isEqualTo(OAuth2ErrorCode.AUTHENTICATION_FAILED.getCode());
+        assertThat(jsonNode.get("message").asText())
+                .isEqualTo(OAuth2ErrorCode.AUTHENTICATION_FAILED.getMessage());
+    }
+
+    @Test
+    @DisplayName("비-OAuth2 인증 예외 발생 시 AUTHENTICATION_FAILED 에러 응답")
+    void testNonOAuth2AuthenticationException() throws IOException {
+        // given
+        BadCredentialsException exception = new BadCredentialsException("인증 실패");
+
+        // when
+        socialFailureHandler.onAuthenticationFailure(request, response, exception);
+
+        // then
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        assertThat(jsonNode.get("success").asBoolean()).isFalse();
+        assertThat(jsonNode.get("code").asText())
+                .isEqualTo(OAuth2ErrorCode.AUTHENTICATION_FAILED.getCode());
+        assertThat(jsonNode.get("message").asText())
+                .isEqualTo(OAuth2ErrorCode.AUTHENTICATION_FAILED.getMessage());
+    }
+
+    @Test
+    @DisplayName("응답 상태 코드와 Content-Type이 올바르게 설정됨")
+    void testResponseStatusAndContentType() throws IOException {
+        // given
+        OAuth2AuthenticationException exception =
+                new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다.");
+
+        // when
+        socialFailureHandler.onAuthenticationFailure(request, response, exception);
+
+        // then
+        // Note: Mockito를 사용하여 verify할 수 있지만, 여기서는 간단히 확인
+        // 실제로는 response.setStatus()와 response.setContentType()이 호출되었는지 확인해야 함
+    }
+}

--- a/src/test/java/com/example/ssccwebbe/global/security/handler/SocialFailureHandlerTest.java
+++ b/src/test/java/com/example/ssccwebbe/global/security/handler/SocialFailureHandlerTest.java
@@ -2,6 +2,7 @@ package com.example.ssccwebbe.global.security.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -114,7 +116,7 @@ class SocialFailureHandlerTest {
         socialFailureHandler.onAuthenticationFailure(request, response, exception);
 
         // then
-        // Note: Mockito를 사용하여 verify할 수 있지만, 여기서는 간단히 확인
-        // 실제로는 response.setStatus()와 response.setContentType()이 호출되었는지 확인해야 함
+        verify(response).setStatus(HttpStatus.UNAUTHORIZED.value());
+        verify(response).setContentType("application/json;charset=UTF-8");
     }
 }

--- a/src/test/java/com/example/ssccwebbe/global/security/jwt/filter/JwtFilterTest.java
+++ b/src/test/java/com/example/ssccwebbe/global/security/jwt/filter/JwtFilterTest.java
@@ -1,0 +1,175 @@
+package com.example.ssccwebbe.global.security.jwt.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.example.ssccwebbe.global.security.jwt.code.JwtErrorCode;
+import com.example.ssccwebbe.global.security.jwt.util.JwtUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class JwtFilterTest {
+
+    private JwtFilter jwtFilter;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain filterChain;
+    private StringWriter stringWriter;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jwtFilter = new JwtFilter();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        filterChain = mock(FilterChain.class);
+        stringWriter = new StringWriter();
+        objectMapper = new ObjectMapper();
+
+        when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+
+        // SecurityContext 초기화
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 필터 체인을 계속 진행")
+    void testNoAuthorizationHeader() throws Exception {
+        // given
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        // when
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("Bearer로 시작하지 않는 토큰은 ApiResponse 형식으로 400 에러 응답")
+    void testInvalidAuthorizationFormat() throws Exception {
+        // given
+        when(request.getHeader("Authorization")).thenReturn("InvalidFormat token");
+
+        // when
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain, never()).doFilter(request, response);
+
+        String responseBody = stringWriter.toString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        assertThat(jsonNode.get("success").asBoolean()).isFalse();
+        assertThat(jsonNode.get("code").asText())
+                .isEqualTo(JwtErrorCode.INVALID_TOKEN_FORMAT.getCode());
+        assertThat(jsonNode.get("message").asText())
+                .isEqualTo(JwtErrorCode.INVALID_TOKEN_FORMAT.getMessage());
+        assertThat(jsonNode.get("data").isNull()).isTrue();
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("유효한 JWT 토큰이면 SecurityContext에 인증 정보 설정")
+    void testValidToken() throws Exception {
+        // given
+        String validToken = "valid.jwt.token";
+        String username = "testuser";
+        String role = "ROLE_USER";
+
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + validToken);
+
+        try (MockedStatic<JwtUtil> mockedJwtUtil = mockStatic(JwtUtil.class)) {
+            mockedJwtUtil.when(() -> JwtUtil.isValid(validToken, true)).thenReturn(true);
+            mockedJwtUtil.when(() -> JwtUtil.getUsername(validToken)).thenReturn(username);
+            mockedJwtUtil.when(() -> JwtUtil.getRole(validToken)).thenReturn(role);
+
+            // when
+            jwtFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            verify(filterChain).doFilter(request, response);
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+            assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
+                    .isEqualTo(username);
+            assertThat(SecurityContextHolder.getContext().getAuthentication().getAuthorities())
+                    .hasSize(1);
+        }
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 JWT 토큰이면 ApiResponse 형식으로 403 에러 응답")
+    void testInvalidToken() throws Exception {
+        // given
+        String invalidToken = "invalid.jwt.token";
+
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + invalidToken);
+
+        try (MockedStatic<JwtUtil> mockedJwtUtil = mockStatic(JwtUtil.class)) {
+            mockedJwtUtil.when(() -> JwtUtil.isValid(invalidToken, true)).thenReturn(false);
+
+            // when
+            jwtFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            verify(filterChain, never()).doFilter(request, response);
+
+            String responseBody = stringWriter.toString();
+            JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+            assertThat(jsonNode.get("success").asBoolean()).isFalse();
+            assertThat(jsonNode.get("code").asText())
+                    .isEqualTo(JwtErrorCode.INVALID_TOKEN.getCode());
+            assertThat(jsonNode.get("message").asText())
+                    .isEqualTo(JwtErrorCode.INVALID_TOKEN.getMessage());
+            assertThat(jsonNode.get("data").isNull()).isTrue();
+
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰 응답이 올바른 JSON 구조를 가짐")
+    void testInvalidTokenJsonStructure() throws Exception {
+        // given
+        String invalidToken = "invalid.jwt.token";
+
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + invalidToken);
+
+        try (MockedStatic<JwtUtil> mockedJwtUtil = mockStatic(JwtUtil.class)) {
+            mockedJwtUtil.when(() -> JwtUtil.isValid(invalidToken, true)).thenReturn(false);
+
+            // when
+            jwtFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            String responseBody = stringWriter.toString();
+            JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+            // ApiResponse의 4가지 필드 검증
+            assertThat(jsonNode.has("success")).isTrue();
+            assertThat(jsonNode.has("code")).isTrue();
+            assertThat(jsonNode.has("message")).isTrue();
+            assertThat(jsonNode.has("data")).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 번호

<!-- 이슈 번호를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #22 

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
공통 응답 포맷 형식에 맞게 에러응답을 제공하여, API 연동시 에러 구분을 명확히 하기 위함입니다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->
모든 시큐리티 관련 파일의 응답 포맷을 확인하고 수정하였으며, 응답포맷에 맞게 테스트 코드의 일부를 수정하였습니다.

-

## 📂 적용 범위

<!-- 변경된 파일/폴더의 범위를 작성해주세요. -->

1. /domain/preuser/code/PreUserErrorCode.java

2. /domain/preuser/service/PreUserServiceImpl.java

3. /global/security/code/OAuth2ErrorCode.java

4. /global/security/config/SecurityConfig.java

5. /global/security/handler/CustomAccessDeniedHandler.java

6. /global/security/handler/CustomAuthenticationEntryPoint.java

7. /global/security/handler/RefreshTokenLogoutHandler.java

8. /global/security/handler/SocialFailureHandler.java

9. /global/security/jwt/code/JwtErrorCode.java

10. /global/security/jwt/filter/JwtFilter.java

11. /domain/preuser/service/PreUserServiceImplTest.java

12. /global/security/handler/CustomAccessDeniedHandlerTest.java

13. /global/security/handler/CustomAuthenticationEntryPointTest.java

-- 이하 테스트 코드 파일 --

14. /global/security/handler/SocialFailureHandlerTest.java

15. /global/security/jwt/filter/JwtFilterTest.java

-

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->
1. SocialFailureHandler
2. CustomAccessDeniedHandler
3. CustomAuthenticationEntryPoint

가 추가 되었으며, 이에 대한 설정은 SecurityConfig.java에서 확인 가능합니다.

```java
package com.example.ssccwebbe.global.security.config;

@Configuration
@EnableWebSecurity // 시큐리티 빈 설정 활성화
public class SecurityConfig {

    private final AuthenticationFailureHandler socialFailureHandler;
    private final AuthenticationEntryPoint authenticationEntryPoint;
    private final AccessDeniedHandler accessDeniedHandler;

 /*-- 생략 --*/

        // OAuth2 인증용
        http.oauth2Login(
                oauth2 ->
                        oauth2.successHandler(socialSuccessHandler)
                                .failureHandler(socialFailureHandler));

 /*-- 생략 --*/

        // 예외 처리
        http.exceptionHandling(
                e ->
                        e.authenticationEntryPoint(authenticationEntryPoint)
                                .accessDeniedHandler(accessDeniedHandler));
 /*-- 생략 --*/
}

```

## 💬 리뷰어에게

스프링 시큐리티 필터는 서블렛 보다 앞단에 위치해 있기에, @RestControllerAdvice 로 처리하는것이 불가능합니다.
물론, resolver를 이용해 예외에 대한 처리를 우회하는 방법이 있긴하지만, 시큐리티 아키텍처가 거대해질 경우 이를 관리하기 따라로워 집니다. 때문에 지정된 시큐리티 필터에서 직접 응답하는 방식으로 구현하였습니다.

이는 Spring Security의 표준 패턴이며, 필터는 서블릿보다 앞에서 동작하기 때문에 필터에서 발생한 예외는 @ControllerAdvice인 GlobalExceptionHandler로 전달되지 않습니다.

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가?
- [x] 관련 테스트 코드를 작성했는가?
- [x] 기존 테스트가 모두 통과하는가? (`./gradlew test`)
- [x] 코드 스타일을 준수하는가? (`./gradlew spotlessCheck checkstyleMain`)

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
